### PR TITLE
fix: prevent zero values in fuzz test random generation

### DIFF
--- a/fundingvault/test/TestFundingVaultProxy.js
+++ b/fundingvault/test/TestFundingVaultProxy.js
@@ -546,8 +546,8 @@ describe("Funding Vault Tests", function () {
 				const granteeAddress = await grantee.getAddress();
 
 				// Generate random values for grant and claim
-				const randomGrant = Math.floor(Math.random() * 1000);
-				const randomTime = Math.floor(Math.random() * 3600);
+				const randomGrant = Math.floor(Math.random() * 1000) + 1;
+				const randomTime = Math.floor(Math.random() * 3600) + 1;
 
 				if (debug) {
 					console.log(`Test ${i + 1}: Grantee = ${granteeAddress}, Grant = ${randomGrant}, Time = ${randomTime}`);


### PR DESCRIPTION
## Summary

- `Math.floor(Math.random() * N)` can produce `0`, which violates the contract's `require(amount > 0 && interval > 0)` check, causing flaky test failures
- Added `+ 1` to both `randomGrant` and `randomTime` to ensure values are always `>= 1`

## Failing test output
https://github.com/ethpandaops/fundingvault/actions/runs/24189269131/job/70601849482#step:6:59
```
  18 passing (1s)
  1 failing

  1) Funding Vault Tests
       Fuzz Testing
         Create Grant fuzzing:
     Error: VM Exception while processing transaction: reverted with reason string 'invalid grant'
    at FundingVaultV1.claimTo (contracts/FundingVaultV1.sol:487)
    at FundingVaultV1.createGrant (contracts/FundingVaultV1.sol:299)
    at FundingVaultProxy._delegate (contracts/FundingVaultProxy.sol:41)
    at FundingVaultProxy._fallback (contracts/FundingVaultProxy.sol:35)
    at FundingVaultProxy.<fallback> (contracts/FundingVaultProxy.sol:54)
    at EdrProviderWrapper.request (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:446:41)
    at HardhatEthersSigner.sendTransaction (node_modules/@nomicfoundation/hardhat-ethers/src/signers.ts:125:18)
    at send (node_modules/ethers/src.ts/contract/contract.ts:313:20)
    at Proxy.createGrant (node_modules/ethers/src.ts/contract/contract.ts:352:16)
    at Context.<anonymous> (test/TestFundingVaultProxy.js:557:5)
```

## Test plan

- [x] All 19 tests passing locally after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)